### PR TITLE
Fix for app binding to 8080 on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar target/envibe-0.0.1-SNAPSHOT.jar
+web: java -Dserver.port=$PORT -jar target/envibe-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
Application was reporting as crashed on Heroku. Added port attribute to `./Procfile` to allow Heroku to set the port to be used.