### PR TITLE
Fixed UML Doclet configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,15 @@
 						<artifactId>umldoclet</artifactId>
 						<version>1.1.4</version>
 					</docletArtifact>
+					<additionalOptions>
+						<umlIncludePrivateFields>true</umlIncludePrivateFields>
+						<umlIncludeDeprecatedFields>true</umlIncludeDeprecatedFields>
+						<umlIncludeMethodParamNames>true</umlIncludeMethodParamNames>
+						<umlIncludeDefaultConstructors>true</umlIncludeDefaultConstructors>
+						<umlIncludePrivateMethods>true</umlIncludePrivateMethods>
+						<umlIncludeDeprecatedMethods>true</umlIncludeDeprecatedMethods>
+						<umlIncludePrivateClasses>true</umlIncludePrivateClasses>
+					</additionalOptions>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
- Fixed an issue where private members, properties, and methods were not included in the generated UML diagrams.
- Updated UML Doclet configuration to match that of the master Javadoc configuration.