### PR TITLE
Fixed Heroku Push Fail

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,0 @@
-.idea
-/target/site
-/target/surefire-reports


### PR DESCRIPTION
- Fixed an issue where the Heroku deploy step on the CI would delete the Javadoc documentation, causing the GitHub Pages deploy step to fail.